### PR TITLE
Removido banco Nossa Caixa

### DIFF
--- a/src/main/java/org/jrimum/bopepo/BancosSuportados.java
+++ b/src/main/java/org/jrimum/bopepo/BancosSuportados.java
@@ -198,12 +198,6 @@ public enum BancosSuportados{
 	CAIXA_ECONOMICA_FEDERAL("104", "00360305000104", "CAIXA ECONOMICA FEDERAL", "Caixa Econômica Federal"),
 
 	/**
-	 * Tipo enumerado que representa o Banco <strong>Nossa Caixa</strong>, código
-	 * de compensação <strong><tt>151</tt></strong> <a href="http://www.nossacaixa.com.br/">site</a>.
-	 */
-	NOSSA_CAIXA("151", "43073394000110", "BANCO NOSSA CAIXA S.A.", "Banco Múltiplo"),	
-			
-	/**
 	 * Tipo enumerado que representa o Banco <strong>Bradesco</strong>, código
 	 * de compensação <strong><tt>237</tt></strong> <a
 	 * href="http://www.bradesco.com.br">site</a>.


### PR DESCRIPTION
O Banco Nossa Caixa foi incorporado ao BB em 2009.
