### PR TITLE
Carteira em representação do nosso número SICOB CAIXA

### DIFF
--- a/src/main/java/org/jrimum/bopepo/view/info/campo/caixa/BoletoInfoViewCaixaSICOB14.java
+++ b/src/main/java/org/jrimum/bopepo/view/info/campo/caixa/BoletoInfoViewCaixaSICOB14.java
@@ -53,4 +53,10 @@ public class BoletoInfoViewCaixaSICOB14 extends AbstractBoletoInfoCampoView {
 		String textoFcLocalPagamento = super.getTextoFcLocalPagamento();
 		return isBlank(textoFcLocalPagamento) ? "PREFERENCIALMENTE NAS CASAS LOTÉRICAS ATÉ O VALOR LIMITE" : textoFcLocalPagamento;
 	}
+        
+        @Override
+	public String getTextoFcNossoNumero() {
+		return getBoleto().getTitulo().getContaBancaria().getCarteira().getCodigo()
+                        + super.getTextoFcNossoNumero();
+	}
 }


### PR DESCRIPTION
Para homologar o boleto com a CAIXA do tipo SICOB sem registro, é necessário exibir o número da carteira junto com o nosso número, na ficha de compensação. Mesma forma de funcionamento do SIGCB.
